### PR TITLE
Add -B and -C context flags to CLI parser; -C overrides -A and -B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `-B` / `--before-context` and `-C` / `--context` CLI flags to argument parser to show context before and after matches. `-C` overrides `-A` and `-B`.
 - Added `-A` / `--after-context` CLI flag to argument parser for specifying number of lines to show after each match.
 - Added docstrings to all test files.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -137,9 +137,31 @@ def parse_arguments() -> argparse.Namespace:
         metavar="NUM",
     )
 
+    parser.add_argument(
+        "-B",
+        "--before-context",
+        help="Print NUM lines of leading context before each match",
+        type=int,
+        default=0,
+        metavar="NUM",
+    )
+
+    parser.add_argument(
+        "-C",
+        "--context",
+        help="Print NUM lines of context before and after each match",
+        type=int,
+        default=0,
+        metavar="NUM",
+    )
+
     args = parser.parse_args()
 
     if args.recursive and not args.files:
         parser.error("at least one FILE required for recursive search")
+
+    if args.context > 0:
+        args.before_context = args.context
+        args.after_context = args.context
 
     return args


### PR DESCRIPTION
Added support for `-B` / `--before-context` and `-C` / `--context` flags in the argument parser.

`-B` allows user to specify the NUM of context lines before a match, `-C` gives NUM of lines before and after. If `-C` is set, it overrides both `-A` and `-B`.

Closes #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-B/--before-context` flag to display context lines before search matches
  * Added `-C/--context` flag to display context lines both before and after search matches
  * When `-C` is specified, it takes precedence over `-A` and `-B` flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->