### PR TITLE
Wiring -A through main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -93,6 +93,7 @@ def main() -> None:
                         ignore_case=args.ignore_case,
                         invert_match=args.invert_match,
                         count_only=args.count,
+                        after_context=args.after_context,
                     ):
                         sys.exit(EXIT_MATCH_FOUND)
                     else:


### PR DESCRIPTION
This pull request completes the implementation of the`-A` flag, after-context, in single-file searches. It is now wired through `main.py` and works correctly. Support for multi-file searching will be added after the remaining context flags have been fully implemented.

Closes #6 